### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ I recommend reading the [Mountebank documentation](http://www.mbtest.org/docs/ap
 
 1. Add these to you environment hash (eg. add to your `.env` file)
 	
-	```
+```
 MOUNTEBANK_SERVER=127.0.0.1
 MOUNTEBANK_PORT=2525
 ```
 
 2. Include the lib in your `spec_helper`.
 
-	```ruby
+```ruby
 include 'mountebank'
 ```
 


### PR DESCRIPTION
A few of the code blocks had leading whitespace before the backticks which caused the examples to render incorrectly.