### PR TITLE
Support behaviours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ mkmf.log
 mb.log
 mb.pid
 tags
+.ruby-version
+.ruby-gemset

--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ Check the URL:
 curl http://127.0.0.1:4545/test
 ```
 
+### Create a response with behaviors
+[Behaviors](http://www.mbtest.org/docs/api/behaviors) can be passed through when creating a stub http response.
+```ruby
+response = Mountebank::Stub::HttpResponse.create(status_code, headers, body, {wait: 1000}) # Wait 1 second before responding
+```
+
+## Running Specs
+
+The current set of specs require the Mountebank instance to be started with the `--mock` flag.
+
 ## Contributing
 
 1. Fork it ( https://github.com/CoderKungfu/mountebank/fork )

--- a/lib/mountebank/stub/http_response.rb
+++ b/lib/mountebank/stub/http_response.rb
@@ -1,11 +1,12 @@
 class Mountebank::Stub::HttpResponse < Mountebank::Stub::Response
-  def self.create(statusCode=200, headers={}, body='')
+  def self.create(statusCode=200, headers={}, body='', behaviors={})
     payload = {}
     payload[:statusCode] = statusCode
     payload[:headers] = headers unless headers.empty?
     payload[:body] = body unless body.empty?
 
     data = {is: payload}
+    data.merge!(_behaviors: behaviors) unless behaviors.empty?
     new(data)
   end
 end

--- a/lib/mountebank/stub/response.rb
+++ b/lib/mountebank/stub/response.rb
@@ -5,6 +5,7 @@ class Mountebank::Stub::Response
     @is = data[:is] || nil
     @proxy = data[:proxy] || nil
     @inject = data[:inject] || nil
+    @behaviors = data[:_behaviors]
   end
 
   def self.with_injection(injection='')
@@ -19,6 +20,7 @@ class Mountebank::Stub::Response
     data[:is] = @is unless @is.nil?
     data[:proxy] = @proxy unless @proxy.nil?
     data[:inject] = @inject unless @inject.nil?
+    data[:_behaviors] = @behaviors unless @behaviors.nil?
     data.to_json(*args)
   end
 end

--- a/spec/mountebank/stub/http_response_spec.rb
+++ b/spec/mountebank/stub/http_response_spec.rb
@@ -5,11 +5,17 @@ RSpec.describe Mountebank::Stub::HttpResponse do
   let(:headers) { {"Content-Type" => "application/json"} }
   let(:body) { {foo:"bar"}.to_json }
   let!(:response) { Mountebank::Stub::HttpResponse.create(statusCode, headers, body) }
+  let!(:response_with_behaviors) { Mountebank::Stub::HttpResponse.create(statusCode, headers, body, {wait: 10000}) }
 
   describe '.create' do
     it 'returns response object' do
       expect(response).to be_a Mountebank::Stub::HttpResponse
       expect(response.to_json).to eq '{"is":{"statusCode":200,"headers":{"Content-Type":"application/json"},"body":"{\"foo\":\"bar\"}"}}'
+    end
+
+    it 'returns a response object' do
+      expect(response_with_behaviors).to be_a Mountebank::Stub::HttpResponse
+      expect(response_with_behaviors.to_json).to eq '{"is":{"statusCode":200,"headers":{"Content-Type":"application/json"},"body":"{\"foo\":\"bar\"}"},"_behaviors":{"wait":10000}}'
     end
   end
 end


### PR DESCRIPTION
Added support for behaviors. Extended the Mountebank::Stub::HttpResponse.create method to take a fourth parameter for behaviours.  With four parameters, it probably makes sense to change the signature - named parameters perhaps, but that would mean a backwards-incompatible change. So, decided to go with just adding a fourth positional parameter.

Have left version number unchanged - adjust as you see fit :)