### PR TITLE
Add Imposter.find_all

### DIFF
--- a/lib/mountebank/imposter.rb
+++ b/lib/mountebank/imposter.rb
@@ -42,6 +42,12 @@ module Mountebank
     def self.create(port, protocol=PROTOCOL_HTTP, options={})
       self.build(port, protocol, options).save!
     end
+    
+    def self.find_all
+      response = Network.get("/imposters")
+      list = response.success? ? response.body[:imposters] : []
+      list.map { |i| Mountebank::Imposter.new(i) }
+    end
 
     def self.find(port)
       imposter_data = Imposter.get_imposter_config(port)

--- a/lib/mountebank/imposter.rb
+++ b/lib/mountebank/imposter.rb
@@ -1,6 +1,6 @@
 module Mountebank
   class Imposter
-    attr_reader :port, :protocol, :name, :stubs, :requests, :matches, :mode
+    attr_reader :port, :protocol, :name, :stubs, :requests, :matches, :mode, :record_requests
 
     PROTOCOL_HTTP = 'http'
     PROTOCOL_HTTPS = 'https'
@@ -104,6 +104,7 @@ module Mountebank
       data[:requests] = @requests unless @requests.empty?
       data[:matches] = @matches unless @matches.empty?
       data[:mode] = @mode unless @mode.nil?
+      data[:recordRequests] = @record_requests unless @record_requests.nil?
 
       data
     end
@@ -127,6 +128,7 @@ module Mountebank
       @requests = data[:requests] || []
       @matches = data[:matches] || []
       @mode = data[:mode] || nil
+      @record_requests = data[:record_requests] || data[:recordRequests] || false
     end
   end
 end

--- a/lib/mountebank/version.rb
+++ b/lib/mountebank/version.rb
@@ -1,3 +1,3 @@
 module Mountebank
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/mountebank.gemspec
+++ b/mountebank.gemspec
@@ -4,9 +4,9 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'mountebank/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "mountebank"
+  spec.name          = "erithmetic-mountebank"
   spec.version       = Mountebank::VERSION
-  spec.authors       = ["Michael Cheng"]
+  spec.authors       = ["Michael Cheng", "Erica Kastner"]
   spec.email         = ["mcheng.work@gmail.com"]
   spec.summary       = %q{Ruby GEM to manage a Mountebank Test Server}
   spec.description   = %q{A simple Ruby library that lets you manage your Mountebank test server.}

--- a/spec/examples_spec.rb
+++ b/spec/examples_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Examples' do
     it 'should create' do
       port = 4545
       protocol = Mountebank::Imposter::PROTOCOL_HTTP
-      imposter = Mountebank::Imposter.create(port, protocol)
+      imposter = Mountebank::Imposter.create(port, protocol, record_requests: true)
 
       expect(imposter.reload.requests).to be_empty
       test_url('http://127.0.0.1:4545')
@@ -27,7 +27,7 @@ RSpec.describe 'Examples' do
     it 'should have stub' do
       port = 4545
       protocol = Mountebank::Imposter::PROTOCOL_HTTP
-      imposter = Mountebank::Imposter.build(port, protocol)
+      imposter = Mountebank::Imposter.build(port, protocol, record_requests: true)
 
       # Create a response
       status_code = 200
@@ -48,7 +48,7 @@ RSpec.describe 'Examples' do
     it 'should have stub & predicate' do
       port = 4545
       protocol = Mountebank::Imposter::PROTOCOL_HTTP
-      imposter = Mountebank::Imposter.build(port, protocol)
+      imposter = Mountebank::Imposter.build(port, protocol, record_requests: true)
 
       # Create a response
       status_code = 200

--- a/spec/mountebank/imposter_spec.rb
+++ b/spec/mountebank/imposter_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Mountebank::Imposter do
           Mountebank::Stub.create(responses, predicates)
         ]
       }
-      let!(:imposter) { Mountebank::Imposter.create(port, protocol, stubs:stubs) }
+      let!(:imposter) { Mountebank::Imposter.create(port, protocol, stubs: stubs, record_requests: true) }
 
       it 'is valid' do
         expect(test_url('http://127.0.0.1:4545')).to eq 'ohai'
@@ -141,7 +141,7 @@ RSpec.describe Mountebank::Imposter do
 
   describe '#reload' do
     before do
-      Mountebank::Imposter.create(port)
+      Mountebank::Imposter.create(port, Mountebank::Imposter::PROTOCOL_HTTP, recordRequests: true)
     end
 
     let!(:imposter) { Mountebank::Imposter.find(port) }
@@ -173,7 +173,15 @@ RSpec.describe Mountebank::Imposter do
       end
 
       it 'adds new stub' do
-        expect(imposter.to_json).to eq("{\"port\":#{port},\"protocol\":\"#{protocol}\",\"name\":\"imposter_#{port}\",\"stubs\":[{\"responses\":[{\"is\":{\"statusCode\":200,\"body\":\"ohai you\"}}]}]}")
+        expect(imposter.to_json).to eq({
+          "port": port,
+          "protocol": protocol,
+          "name": "imposter_#{port}",
+          "stubs": [{
+            "responses": [{"is":{"statusCode":200, "body":"ohai you"}}]
+          }],
+          "recordRequests": false
+        }.to_json)
       end
 
       it 'is valid imposter' do
@@ -253,7 +261,12 @@ RSpec.describe Mountebank::Imposter do
     let(:imposter) { Mountebank::Imposter.build(port, protocol) }
 
     it 'returns valid data' do
-      expect(imposter.replayable_data).to eq({port:port, protocol:protocol, name:"imposter_#{port}"})
+      expect(imposter.replayable_data).to eq({
+        port: port,
+        protocol: protocol,
+        name: "imposter_#{port}",
+        recordRequests: false
+      })
     end
   end
 end

--- a/spec/mountebank/imposter_spec.rb
+++ b/spec/mountebank/imposter_spec.rb
@@ -121,6 +121,29 @@ RSpec.describe Mountebank::Imposter do
     end
   end
 
+  describe '.find_all' do
+    context '0 existing imposters' do
+      it 'returns an empty array' do
+        expect(Mountebank::Imposter.find_all).to be_empty
+      end
+    end
+
+    context '1 existing imposter' do
+      it 'returns a single imposter' do
+        Mountebank::Imposter.create(4546)
+        expect(Mountebank::Imposter.find_all.map(&:port)).to eq([4546])
+      end
+    end
+
+    context '3 existing imposters' do
+      it 'returns all three imposters' do
+        Mountebank::Imposter.create(4546)
+        Mountebank::Imposter.create(4547)
+        expect(Mountebank::Imposter.find_all.map(&:port).sort).to eq([4546, 4547])
+      end
+    end
+  end
+
   describe '.delete' do
     before do
       Mountebank::Imposter.create(port)


### PR DESCRIPTION
Returns all imposters. Useful for cleanup on test runs. This builds on top of #9 