### PR TITLE
Upgraded faraday to v1.0.0 to pick up a bug they fixed

### DIFF
--- a/mountebank.gemspec
+++ b/mountebank.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "faraday", "~>0.9.0"
+  spec.add_runtime_dependency "faraday", "~>1.0.0"
   spec.add_runtime_dependency "faraday_middleware"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/mountebank.gemspec
+++ b/mountebank.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "faraday", "~>1.0.0"
-  spec.add_runtime_dependency "faraday_middleware"
+  spec.add_runtime_dependency "faraday_middleware", "~>1.2.0"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "dotenv", "~> 1.0.0"


### PR DESCRIPTION
Faraday 0.9.0 had a bug which resulted in an error which was preventing my rails app from starting. It was fixed in v 1.0.0

Here's the issue on Faraday: https://github.com/lostisland/faraday/issues/961
