### PR TITLE
Upgrade all dependencies

### DIFF
--- a/lib/mountebank/helper.rb
+++ b/lib/mountebank/helper.rb
@@ -34,6 +34,6 @@ module Mountebank
   end
 
   if ::Faraday::Middleware.respond_to? :register_middleware
-    ::Faraday::Response.register_middleware :symbolize_keys => lambda { Mountebank::SymbolizeKeys }
+    ::Faraday::Response.register_middleware :symbolize_keys => Mountebank::SymbolizeKeys
   end
 end

--- a/lib/mountebank/network.rb
+++ b/lib/mountebank/network.rb
@@ -1,5 +1,4 @@
 require 'faraday'
-require 'faraday_middleware'
 
 module Mountebank
   class Network

--- a/mountebank.gemspec
+++ b/mountebank.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "faraday", "~>2.0.0"
-  spec.add_runtime_dependency "faraday_middleware"
+  spec.add_runtime_dependency "faraday", "~>1.0.0"
+  spec.add_runtime_dependency "faraday_middleware", "~>1.2.0"
   spec.add_development_dependency "bundler", "~> 2.3"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "dotenv", "~> 2.7.6"

--- a/mountebank.gemspec
+++ b/mountebank.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "faraday", "~>0.9.0"
+  spec.add_runtime_dependency "faraday", "~>2.0.0"
   spec.add_runtime_dependency "faraday_middleware"
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "dotenv", "~> 1.0.0"
+  spec.add_development_dependency "bundler", "~> 2.3"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "dotenv", "~> 2.7.6"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
 end

--- a/mountebank.gemspec
+++ b/mountebank.gemspec
@@ -18,8 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "faraday", "~>1.0.0"
-  spec.add_runtime_dependency "faraday_middleware", "~>1.2.0"
+  spec.add_runtime_dependency "faraday", "~>2.0.0"
   spec.add_development_dependency "bundler", "~> 2.3"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "dotenv", "~> 2.7.6"


### PR DESCRIPTION
Tried to upgrade all dependencies, for no particular reason while I was upgrading Faraday.

I was not able to upgrade to Faraday 2.0.0 though due to faraday_middleware not being compatible with it. So left it for now.